### PR TITLE
Post Model Update

### DIFF
--- a/FirebaseTestProject/Models/Post.swift
+++ b/FirebaseTestProject/Models/Post.swift
@@ -13,13 +13,15 @@ struct Post: FirebaseConvertable {
     let author: String
     let text: String
     let id: UUID
+    var imageURL: String
     let timestamp: Date
     
-    init(title: String, text: String, author: String) {
+    init(title: String, text: String, author: String, imageURL: String = "no image") {
         self.title = title
         self.author = author
         self.text = text
         self.id = UUID()
+        self.imageURL = imageURL
         self.timestamp = Date()
     }
     static let testPost = Post(title: "Title", text: "Content", author: "First Last")


### PR DESCRIPTION
Posts now have an imageURL field in the Firebase Firestore DB. Older/other versions are saving posts to the DB without this field that is causing decoding errors in versions that have a model looking for an imageURL.

Only changes here are three lines added to the Post.swift file, this will make it backward compatible (no image versions will still be able to load/view/create posts, just won't be presented with images.

- Add "var imageURL: String" to instance properties
- Add parameter w/ default initializer to init ", imageURL: String = "no image""
- Add "self.imageURL = imageURL" to property initializer in init

Please throw these lines into all Post.swift's that are out there. I've been manually going through the Firebase DB and adding an imageURL field to each document as it is created by other versions of the app but there are too many now for me to keep up.