### PR TITLE
Add CI workflow with GitHub Actions

### DIFF
--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -1,0 +1,44 @@
+name: iOS starter workflow
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build:
+    name: Build and Test default scheme using any available iPhone simulator
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set Default Scheme
+        run: |
+          scheme_list=$(xcodebuild -list -json | tr -d "\n")
+          default=$(echo $scheme_list | ruby -e "require 'json'; puts JSON.parse(STDIN.gets)['project']['targets'][0]")
+          echo $default | cat >default
+          echo Using default scheme: $default
+      - name: Build
+        env:
+          scheme: ${{ 'default' }}
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
+      - name: Test
+        env:
+          scheme: ${{ 'default' }}
+          platform: ${{ 'iOS Simulator' }}
+        run: |
+          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          if [ $scheme = default ]; then scheme=$(cat default); fi
+          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
+          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
+          xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    name: Build and test default scheme using any available iPhone 12 simulator
+    name: Build default scheme using any available iPhone 12 simulator
     runs-on: macos-11
 
     steps:
@@ -35,14 +35,3 @@ jobs:
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
           xcodebuild build-for-testing -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"
-      - name: Test
-        env:
-          scheme: ${{ 'default' }}
-          platform: ${{ 'iOS Simulator' }}
-        run: |
-          # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone 12' | head -1 | awk '{$1=$1;print}'`
-          if [ $scheme = default ]; then scheme=$(cat default); fi
-          if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
-          file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
-          xcodebuild test-without-building -scheme "$scheme" -"$filetype_parameter" "$file_to_build" -destination "platform=$platform,name=$device"

--- a/.github/workflows/ios.yml
+++ b/.github/workflows/ios.yml
@@ -8,10 +8,14 @@ on:
 
 jobs:
   build:
-    name: Build and Test default scheme using any available iPhone simulator
-    runs-on: macos-latest
+    name: Build and test default scheme using any available iPhone 12 simulator
+    runs-on: macos-11
 
     steps:
+      - name: Setup Xcode version
+        uses: maxim-lobanov/setup-xcode@v1.3.0
+        with:
+          xcode-version: latest
       - name: Checkout
         uses: actions/checkout@v2
       - name: Set Default Scheme
@@ -26,7 +30,7 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone 12' | head -1 | awk '{$1=$1;print}'`
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`
@@ -37,7 +41,7 @@ jobs:
           platform: ${{ 'iOS Simulator' }}
         run: |
           # xcrun xctrace returns via stderr, not the expected stdout (see https://developer.apple.com/forums/thread/663959)
-          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone.*?[^\(]+' | head -1 | awk '{$1=$1;print}'`
+          device=`xcrun xctrace list devices 2>&1 | grep -oE 'iPhone 12' | head -1 | awk '{$1=$1;print}'`
           if [ $scheme = default ]; then scheme=$(cat default); fi
           if [ "`ls -A | grep -i \\.xcworkspace\$`" ]; then filetype_parameter="workspace" && file_to_build="`ls -A | grep -i \\.xcworkspace\$`"; else filetype_parameter="project" && file_to_build="`ls -A | grep -i \\.xcodeproj\$`"; fi
           file_to_build=`echo $file_to_build | awk '{$1=$1;print}'`

--- a/FirebaseTestProject.xcodeproj/project.pbxproj
+++ b/FirebaseTestProject.xcodeproj/project.pbxproj
@@ -19,20 +19,10 @@
 		F2576ED726C1978F00D3F344 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F2576ED626C1978F00D3F344 /* FirebaseAuth */; };
 		F2576ED926C1978F00D3F344 /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = F2576ED826C1978F00D3F344 /* FirebaseFirestore */; };
 		F2576EDB26C19A3C00D3F344 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EDA26C19A3C00D3F344 /* Post.swift */; };
-		F2576EDC26C19A3C00D3F344 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EDA26C19A3C00D3F344 /* Post.swift */; };
-		F2576EDD26C19A3C00D3F344 /* Post.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EDA26C19A3C00D3F344 /* Post.swift */; };
 		F2576EDF26C19ED000D3F344 /* PostData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EDE26C19ED000D3F344 /* PostData.swift */; };
-		F2576EE026C19ED000D3F344 /* PostData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EDE26C19ED000D3F344 /* PostData.swift */; };
-		F2576EE126C19ED000D3F344 /* PostData.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EDE26C19ED000D3F344 /* PostData.swift */; };
 		F2576EE326C1A1A600D3F344 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EE226C1A1A600D3F344 /* MainTabView.swift */; };
-		F2576EE426C1A1A600D3F344 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EE226C1A1A600D3F344 /* MainTabView.swift */; };
-		F2576EE526C1A1A600D3F344 /* MainTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EE226C1A1A600D3F344 /* MainTabView.swift */; };
 		F2576EEA26C1A2FA00D3F344 /* NewPostForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EE926C1A2FA00D3F344 /* NewPostForm.swift */; };
-		F2576EEB26C1A2FA00D3F344 /* NewPostForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EE926C1A2FA00D3F344 /* NewPostForm.swift */; };
-		F2576EEC26C1A2FA00D3F344 /* NewPostForm.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EE926C1A2FA00D3F344 /* NewPostForm.swift */; };
 		F2576EEE26C1B67E00D3F344 /* PostRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EED26C1B67E00D3F344 /* PostRow.swift */; };
-		F2576EEF26C1B67E00D3F344 /* PostRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EED26C1B67E00D3F344 /* PostRow.swift */; };
-		F2576EF026C1B67E00D3F344 /* PostRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2576EED26C1B67E00D3F344 /* PostRow.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -337,11 +327,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F2576EBB26C18A1B00D3F344 /* FirebaseTestProjectTests.swift in Sources */,
-				F2576EE026C19ED000D3F344 /* PostData.swift in Sources */,
-				F2576EDC26C19A3C00D3F344 /* Post.swift in Sources */,
-				F2576EE426C1A1A600D3F344 /* MainTabView.swift in Sources */,
-				F2576EEF26C1B67E00D3F344 /* PostRow.swift in Sources */,
-				F2576EEB26C1A2FA00D3F344 /* NewPostForm.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -350,11 +335,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				F2576EC526C18A1B00D3F344 /* FirebaseTestProjectUITests.swift in Sources */,
-				F2576EE126C19ED000D3F344 /* PostData.swift in Sources */,
-				F2576EDD26C19A3C00D3F344 /* Post.swift in Sources */,
-				F2576EE526C1A1A600D3F344 /* MainTabView.swift in Sources */,
-				F2576EF026C1B67E00D3F344 /* PostRow.swift in Sources */,
-				F2576EEC26C1A2FA00D3F344 /* NewPostForm.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -559,7 +539,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 76LC8AC986;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -584,7 +564,7 @@
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = 76LC8AC986;
 				GENERATE_INFOPLIST_FILE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",


### PR DESCRIPTION
This adds a simple CI workflow from GitHub Actions to our project. All it does is ensure that the app still compiles, though it can be expanded in the future to include other checks (e.g. running tests).

This should help with our other open PRs.