### PR TITLE
Authentication improvements

### DIFF
--- a/FirebaseTestProject.xcodeproj/project.pbxproj
+++ b/FirebaseTestProject.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		41CF7E7026CC312A0043EB96 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7E6D26CC312A0043EB96 /* SignUpView.swift */; };
 		41CF7E7126CC312A0043EB96 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7E6E26CC312A0043EB96 /* ProfileView.swift */; };
 		41CF7E7226CC312A0043EB96 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7E6F26CC312A0043EB96 /* SignInView.swift */; };
+		5230FE9926D9A45E00BC956C /* AuthViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5230FE9826D9A45E00BC956C /* AuthViewModel.swift */; };
 		52917CC226D162B20061E69F /* FirebaseConvertable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52917CC126D162B20061E69F /* FirebaseConvertable.swift */; };
 		52917CC526D162ED0061E69F /* PostService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52917CC426D162ED0061E69F /* PostService.swift */; };
 		52917CCB26D16AE60061E69F /* UserService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52917CCA26D16AE60061E69F /* UserService.swift */; };
@@ -54,6 +55,7 @@
 		41CF7E6D26CC312A0043EB96 /* SignUpView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		41CF7E6E26CC312A0043EB96 /* ProfileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		41CF7E6F26CC312A0043EB96 /* SignInView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
+		5230FE9826D9A45E00BC956C /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
 		52917CC126D162B20061E69F /* FirebaseConvertable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FirebaseConvertable.swift; sourceTree = "<group>"; };
 		52917CC426D162ED0061E69F /* PostService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostService.swift; sourceTree = "<group>"; };
 		52917CCA26D16AE60061E69F /* UserService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserService.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 			isa = PBXGroup;
 			children = (
 				F2576EDE26C19ED000D3F344 /* PostData.swift */,
+				5230FE9826D9A45E00BC956C /* AuthViewModel.swift */,
 				529271FE26D7003500A35315 /* TaskViewModel.swift */,
 			);
 			path = ViewModels;
@@ -364,6 +367,7 @@
 				52917CC526D162ED0061E69F /* PostService.swift in Sources */,
 				41CF7E7026CC312A0043EB96 /* SignUpView.swift in Sources */,
 				41CF7E7226CC312A0043EB96 /* SignInView.swift in Sources */,
+				5230FE9926D9A45E00BC956C /* AuthViewModel.swift in Sources */,
 				F2576EE326C1A1A600D3F344 /* MainTabView.swift in Sources */,
 				529271FF26D7003500A35315 /* TaskViewModel.swift in Sources */,
 				52917CCD26D16AF00061E69F /* User.swift in Sources */,

--- a/FirebaseTestProject/Services/UserService.swift
+++ b/FirebaseTestProject/Services/UserService.swift
@@ -12,11 +12,13 @@ import FirebaseFirestore
 struct UserService {
     var auth = Auth.auth()
     var usersReference = Firestore.firestore().collection("users")
+    var cache = Cache<User>(key: "user")
     
     func createAccount(name: String, email: String, password: String) async throws -> User {
         let response = try await auth.createUser(withEmail: email, password: password)
         let createdUser = User(name: name)
         try await usersReference.document(response.user.uid).setData(createdUser.jsonDict)
+        cache.save(createdUser)
         return createdUser
     }
     
@@ -25,7 +27,12 @@ struct UserService {
         guard let signedInUser = try await user(response.user.uid) else {
             preconditionFailure("Cannot find user \(response.user.uid) (email: \(email), password: \(password))")
         }
+        cache.save(signedInUser)
         return signedInUser
+    }
+    
+    func currentUser() -> User? {
+        cache.load()
     }
     
     func currentUser() async throws -> User? {
@@ -35,11 +42,13 @@ struct UserService {
         guard let user = try await user(uid) else {
             preconditionFailure("Cannot find current user \(uid)")
         }
+        cache.save(user)
         return user
     }
     
     func signOut() throws {
         try auth.signOut()
+        cache.save(nil)
     }
     
     private func user(_ uid: String) async throws -> User? {
@@ -48,5 +57,25 @@ struct UserService {
             return nil
         }
         return User(from: userData)
+    }
+    
+    struct Cache<Record: Codable> {
+        var key: String
+        var defaults = UserDefaults.standard
+        
+        func load() -> Record? {
+            if let data = defaults.data(forKey: key), let record = try? JSONDecoder().decode(Record.self, from: data) {
+                return record
+            }
+            return nil
+        }
+        
+        func save(_ record: Record?) {
+            if let record = record, let data = try? JSONEncoder().encode(record) {
+                defaults.set(data, forKey: key)
+            } else {
+                defaults.set(nil, forKey: key)
+            }
+        }
     }
 }

--- a/FirebaseTestProject/Services/UserService.swift
+++ b/FirebaseTestProject/Services/UserService.swift
@@ -9,46 +9,25 @@ import Foundation
 import FirebaseAuth
 import FirebaseFirestore
 
-@MainActor class UserService: ObservableObject {
-    @Published var user: User?
+struct UserService {
+    var auth = Auth.auth()
+    var usersReference = Firestore.firestore().collection("users")
     
-    private var auth = Auth.auth()
-    private var users = Firestore.firestore().collection("users")
-    private var listener: AuthStateDidChangeListenerHandle?
-    
-    init() {
-        Task {
-            user = try? await currentUser()
-        }
-        listener = auth.addStateDidChangeListener { _, _ in
-            Task { [weak self] in
-                guard let self = self else { return }
-                self.user = try? await self.currentUser()
-            }
-        }
-    }
-    
-    func createAccount(name: String, email: String, password: String) async throws {
+    func createAccount(name: String, email: String, password: String) async throws -> User {
         let response = try await auth.createUser(withEmail: email, password: password)
         let createdUser = User(name: name)
-        try await users.document(response.user.uid).setData(createdUser.jsonDict)
-        user = createdUser
+        try await usersReference.document(response.user.uid).setData(createdUser.jsonDict)
+        return createdUser
     }
     
-    func signIn(email: String, password: String) async throws {
+    func signIn(email: String, password: String) async throws -> User {
         let response = try await auth.signIn(withEmail: email, password: password)
         guard let signedInUser = try await user(response.user.uid) else {
             preconditionFailure("Cannot find user \(response.user.uid) (email: \(email), password: \(password))")
         }
-        user = signedInUser
+        return signedInUser
     }
     
-    func signOut() throws {
-        try auth.signOut()
-    }
-}
-
-private extension UserService {
     func currentUser() async throws -> User? {
         guard let uid = auth.currentUser?.uid else {
             return nil
@@ -59,8 +38,12 @@ private extension UserService {
         return user
     }
     
-    func user(_ uid: String) async throws -> User? {
-        let user = try await users.document(uid).getDocument()
+    func signOut() throws {
+        try auth.signOut()
+    }
+    
+    private func user(_ uid: String) async throws -> User? {
+        let user = try await usersReference.document(uid).getDocument()
         guard let userData = user.data() else {
             return nil
         }

--- a/FirebaseTestProject/ViewModels/AuthViewModel.swift
+++ b/FirebaseTestProject/ViewModels/AuthViewModel.swift
@@ -1,0 +1,35 @@
+//
+//  AuthViewModel.swift
+//  AuthViewModel
+//
+//  Created by John Royal on 8/26/21.
+//
+
+import Foundation
+
+@MainActor class AuthViewModel: ObservableObject {
+    @Published var user: User?
+    
+    private let userService: UserService
+    
+    init(userService: UserService = .init()) {
+        self.userService = userService
+        
+        Task {
+            user = try await userService.currentUser()
+        }
+    }
+    
+    func createAccount(name: String, email: String, password: String) async throws {
+        user = try await userService.createAccount(name: name, email: email, password: password)
+    }
+    
+    func signIn(email: String, password: String) async throws {
+        user = try await userService.signIn(email: email, password: password)
+    }
+    
+    func signOut() throws {
+        try userService.signOut()
+        user = nil
+    }
+}

--- a/FirebaseTestProject/ViewModels/AuthViewModel.swift
+++ b/FirebaseTestProject/ViewModels/AuthViewModel.swift
@@ -13,6 +13,7 @@ import Foundation
     private let userService: UserService
     
     init(userService: UserService = .init()) {
+        self.user = userService.currentUser()
         self.userService = userService
         
         Task {

--- a/FirebaseTestProject/Views/MainTabView.swift
+++ b/FirebaseTestProject/Views/MainTabView.swift
@@ -8,10 +8,10 @@
 import SwiftUI
 
 struct MainTabView: View {
-    @StateObject private var userService = UserService()
+    @StateObject private var auth = AuthViewModel()
     
     var body: some View {
-        if let user = userService.user {
+        if let user = auth.user {
             authenticatedView(user)
         } else {
             unauthenticatedView
@@ -28,7 +28,7 @@ struct MainTabView: View {
                 .tabItem {
                     Label("New Post", systemImage: "plus.circle")
                 }
-            ProfileView(user: user, signOutAction: userService.signOut)
+            ProfileView(user: user, signOutAction: auth.signOut)
                 .tabItem {
                     Label("Profile", systemImage: "gear")
                 }
@@ -38,8 +38,8 @@ struct MainTabView: View {
     
     private var unauthenticatedView: some View {
         SignInView(
-            action: userService.signIn(email:password:),
-            createAccountView: SignUpView(action: userService.createAccount(name:email:password:))
+            action: auth.signIn(email:password:),
+            createAccountView: SignUpView(action: auth.createAccount(name:email:password:))
         )
     }
 }


### PR DESCRIPTION
This separates the `AuthViewModel` from the `UserService`. The reason for this change is separation of concerns:
* The `AuthViewModel` stores authentication state and interacts with the `UserService`.
* The `UserService` is stateless and tasked only with obtaining `User` objects from Firebase.

In other words, the relationship between the `AuthViewModel` and the `UserService` is analogous to that between the `PostData` view model and the `PostService`.

This also resolves another issue: the app takes a long time to restore authentication state after being launched. During this time, the sign-in screen is displayed, which may be confusing for users. To resolve this issue, the `UserService` now caches the authenticated user in `UserDefaults`, resulting in significantly improved performance.