### PR TITLE
post and profile images

### DIFF
--- a/FirebaseTestProject.xcodeproj/project.pbxproj
+++ b/FirebaseTestProject.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		4159238826DD17AB0012BB86 /* ImagePicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4159238726DD17AB0012BB86 /* ImagePicker.swift */; };
+		4159238B26DD24E60012BB86 /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = 4159238A26DD24E60012BB86 /* FirebaseStorage */; };
 		41CF7E7026CC312A0043EB96 /* SignUpView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7E6D26CC312A0043EB96 /* SignUpView.swift */; };
 		41CF7E7126CC312A0043EB96 /* ProfileView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7E6E26CC312A0043EB96 /* ProfileView.swift */; };
 		41CF7E7226CC312A0043EB96 /* SignInView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41CF7E6F26CC312A0043EB96 /* SignInView.swift */; };
@@ -51,6 +53,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		4159238726DD17AB0012BB86 /* ImagePicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImagePicker.swift; sourceTree = "<group>"; };
 		41CF7E6D26CC312A0043EB96 /* SignUpView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignUpView.swift; sourceTree = "<group>"; };
 		41CF7E6E26CC312A0043EB96 /* ProfileView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ProfileView.swift; sourceTree = "<group>"; };
 		41CF7E6F26CC312A0043EB96 /* SignInView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SignInView.swift; sourceTree = "<group>"; };
@@ -83,6 +86,7 @@
 			files = (
 				F2576ED726C1978F00D3F344 /* FirebaseAuth in Frameworks */,
 				F2576ED926C1978F00D3F344 /* FirebaseFirestore in Frameworks */,
+				4159238B26DD24E60012BB86 /* FirebaseStorage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -103,6 +107,13 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		4159238926DD24E60012BB86 /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		52917CC026D162910061E69F /* Utilities */ = {
 			isa = PBXGroup;
 			children = (
@@ -127,6 +138,7 @@
 				F2576EB926C18A1B00D3F344 /* FirebaseTestProjectTests */,
 				F2576EC326C18A1B00D3F344 /* FirebaseTestProjectUITests */,
 				F2576EA726C18A1700D3F344 /* Products */,
+				4159238926DD24E60012BB86 /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -208,6 +220,7 @@
 				41CF7E6E26CC312A0043EB96 /* ProfileView.swift */,
 				41CF7E6F26CC312A0043EB96 /* SignInView.swift */,
 				41CF7E6D26CC312A0043EB96 /* SignUpView.swift */,
+				4159238726DD17AB0012BB86 /* ImagePicker.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -231,6 +244,7 @@
 			packageProductDependencies = (
 				F2576ED626C1978F00D3F344 /* FirebaseAuth */,
 				F2576ED826C1978F00D3F344 /* FirebaseFirestore */,
+				4159238A26DD24E60012BB86 /* FirebaseStorage */,
 			);
 			productName = FirebaseTestProject;
 			productReference = F2576EA626C18A1700D3F344 /* FirebaseTestProject.app */;
@@ -365,6 +379,7 @@
 				41CF7E7026CC312A0043EB96 /* SignUpView.swift in Sources */,
 				41CF7E7226CC312A0043EB96 /* SignInView.swift in Sources */,
 				F2576EE326C1A1A600D3F344 /* MainTabView.swift in Sources */,
+				4159238826DD17AB0012BB86 /* ImagePicker.swift in Sources */,
 				529271FF26D7003500A35315 /* TaskViewModel.swift in Sources */,
 				52917CCD26D16AF00061E69F /* User.swift in Sources */,
 			);
@@ -727,6 +742,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		4159238A26DD24E60012BB86 /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F2576ED526C1978F00D3F344 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
 		F2576ED626C1978F00D3F344 /* FirebaseAuth */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = F2576ED526C1978F00D3F344 /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;

--- a/FirebaseTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/FirebaseTestProject.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -51,8 +51,8 @@
         "repositoryURL": "https://github.com/google/GoogleUtilities.git",
         "state": {
           "branch": null,
-          "revision": "beb713a16b50a4df3162b3f3ecdeffa16b74b773",
-          "version": "7.5.0"
+          "revision": "2e364ff22e952c3bcb202263a9a0d26e46c1b172",
+          "version": "7.5.1"
         }
       },
       {

--- a/FirebaseTestProject/Models/Post.swift
+++ b/FirebaseTestProject/Models/Post.swift
@@ -11,15 +11,17 @@ struct Post: Identifiable, Equatable, FirebaseConvertable {
     let title: String
     let text: String
     let author: User
+    var imageURL: String
     let id: UUID
     let timestamp: Date
     
-    init(title: String, text: String, author: User, id: UUID = .init(), timestamp: Date = .init()) {
+    init(title: String, text: String, author: User, imageURL: String = "", id: UUID = .init(), timestamp: Date = .init()) {
         self.title = title
         self.text = text
         self.author = author
         self.id = id
         self.timestamp = timestamp
+        self.imageURL = imageURL
     }
     static let testPost = Post(title: "Title", text: "Content", author: "First Last")
     
@@ -39,12 +41,13 @@ struct Post: Identifiable, Equatable, FirebaseConvertable {
 
 extension Post {
     @available(*, deprecated, message: "Specify the author with a User object instead.")
-    init(title: String, text: String, author: String) {
+    init(title: String, text: String, author: String, imageURL: String = "") {
         self.title = title
-        self.author = .init(name: author)
+        self.author = .init(id: UUID().uuidString, name: author)
         self.text = text
         self.id = UUID()
         self.timestamp = Date()
+        self.imageURL = imageURL
     }
 }
 

--- a/FirebaseTestProject/Models/User.swift
+++ b/FirebaseTestProject/Models/User.swift
@@ -8,13 +8,15 @@
 import Foundation
 
 struct User: Equatable, FirebaseConvertable {
-    let id: UUID
+    let id: String
+    var imageURL: String
     var name: String
+
     
-    init(id: UUID = .init(), name: String) {
+    init(id: String, name: String, imageURL: String = "https://firebasestorage.googleapis.com/v0/b/instacademy-test1.appspot.com/o/images%2Fusers%2Fdefault_profile.png?alt=media&token=6700ffd7-2675-45ad-a197-bb2e4e307da7") {
         self.id = id
         self.name = name
+        self.imageURL = imageURL
     }
-    
-    static let testUser = User(name: "Jane Doe")
+    static let testUser = User(id: UUID().uuidString, name: "Jane Doe")
 }

--- a/FirebaseTestProject/Services/UserService.swift
+++ b/FirebaseTestProject/Services/UserService.swift
@@ -8,12 +8,18 @@
 import Foundation
 import FirebaseAuth
 import FirebaseFirestore
+import FirebaseStorage
+import UIKit
 
 @MainActor class UserService: ObservableObject {
     @Published var user: User?
     
     private var auth = Auth.auth()
     private var users = Firestore.firestore().collection("users")
+    static var usersReference: CollectionReference {
+        let db = Firestore.firestore()
+        return db.collection("users")
+    }
     private var listener: AuthStateDidChangeListenerHandle?
     
     init() {
@@ -30,7 +36,7 @@ import FirebaseFirestore
     
     func createAccount(name: String, email: String, password: String) async throws {
         let response = try await auth.createUser(withEmail: email, password: password)
-        let createdUser = User(name: name)
+        let createdUser = User(id: response.user.uid, name: name)
         try await users.document(response.user.uid).setData(createdUser.jsonDict)
         user = createdUser
     }
@@ -45,6 +51,38 @@ import FirebaseFirestore
     
     func signOut() throws {
         try auth.signOut()
+    }
+    static func updateURL(_ user: User, imageURL: String) {
+//        usersReference.document(user.id).setValue(imageURL, forKey: "imageURL")
+        usersReference.document(user.id).updateData(["imageURL": imageURL])
+//        usersReference.child(user.id).setValue(["imageURL": imageURL])
+    }
+    
+    static var imagesRef: StorageReference {
+        let storage = Storage.storage()
+        let storageRef = storage.reference()
+        return storageRef.child("images/users")
+    }
+    
+    static func uploadPhoto(_ user: User, image: UIImage) async -> String{
+        let postImageRef = imagesRef.child("\(user.id).jpg")
+        var imageURL = ""
+        if let imageData = image.jpegData(compressionQuality: 0.75) {
+            // withCheckedContinuation creates an async function out of the putData completion handler
+            await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+                postImageRef.putData(imageData, metadata: nil) { metadata, error in
+                    continuation.resume()
+                }
+            }
+        }
+        do {
+            imageURL = try await postImageRef.downloadURL().absoluteString
+            try await usersReference.document(user.id).updateData(["imageURL": imageURL])
+            return imageURL
+        } catch {
+            print("There was an error obtaining the download URL: \(error)")
+        }
+        return imageURL
     }
 }
 

--- a/FirebaseTestProject/Views/ImagePicker.swift
+++ b/FirebaseTestProject/Views/ImagePicker.swift
@@ -1,0 +1,48 @@
+//
+//  ImagePicker.swift
+//  ImagePicker
+//
+//  Created by Tim Miller on 8/30/21.
+//
+
+import UIKit
+import SwiftUI
+
+struct ImagePickerView: UIViewControllerRepresentable {
+    
+    @Binding var selectedImage: UIImage?
+    @Environment(\.presentationMode) var isPresented
+    
+    var sourceType: UIImagePickerController.SourceType
+    
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let imagePicker = UIImagePickerController()
+        imagePicker.sourceType = self.sourceType
+        imagePicker.delegate = context.coordinator
+        return imagePicker
+    }
+    
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {
+        
+    }
+    
+    func makeCoordinator() -> Coordinator {
+        return Coordinator(picker: self)
+    }
+}
+
+
+class Coordinator: NSObject, UINavigationControllerDelegate, UIImagePickerControllerDelegate {
+    var picker: ImagePickerView
+    
+    init(picker: ImagePickerView) {
+        self.picker = picker
+    }
+    
+    func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
+        guard let selectedImage = info[.originalImage] as? UIImage else { return }
+        self.picker.selectedImage = selectedImage
+        self.picker.isPresented.wrappedValue.dismiss()
+    }
+    
+}

--- a/FirebaseTestProject/Views/NewPostForm.swift
+++ b/FirebaseTestProject/Views/NewPostForm.swift
@@ -8,33 +8,87 @@
 import SwiftUI
 
 struct NewPostForm: View {
-    @State private var title = ""
-    @State private var postContent = ""
+    @State private var title = "Title"
+    @State private var postContent = "Post Content"
+    @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
+    @State private var isSelectingImage = false
+    @State private var image: UIImage?
+    
     @FocusState private var showingKeyboard: Bool
+    
     @StateObject private var submitTask = TaskViewModel()
+    
     @Environment(\.user) private var user
+
     
     var body: some View {
         Form {
             TextField("Title", text: $title)
                 .focused($showingKeyboard)
-            TextField("Post content", text: $postContent)
+            TextEditor(text: $postContent)
                 .focused($showingKeyboard)
+                .multilineTextAlignment(/*@START_MENU_TOKEN@*/.leading/*@END_MENU_TOKEN@*/)
+                .frame(width: 300, height: 300, alignment: .topLeading)
+                
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 200, height: 200, alignment: .center)
+            } else {
+                Image(systemName: "photo")
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 200, height: 200, alignment: .center)
+            }
+            VStack {
+                HStack {
+                    Text("Attach image from:")
+                        .foregroundColor(Color.blue)
+                        .padding(.trailing, 30)
+                    Button {
+                        sourceType = .photoLibrary
+                        isSelectingImage.toggle()
+                    }  label: {
+                        Image(systemName: "photo")
+                            .resizable()
+                            .frame(width: 35, height: 25)
+                            .padding(.trailing, 30)
+                    }
+                    Button {
+                        sourceType = .camera
+                        isSelectingImage.toggle()
+                    }  label: {
+                        Image(systemName: "camera")
+                            .resizable()
+                            .frame(width: 35, height: 25)
+                    }
+                }
+                .buttonStyle(.borderless)
+            }
             Button("Submit", action: submitPost)
         }
         .alert("Cannot Submit Post", isPresented: $submitTask.isError, presenting: submitTask.error) { error in
             Text(error.localizedDescription)
         }
+        .sheet(isPresented: $isSelectingImage) {
+            ImagePickerView(selectedImage: $image, sourceType: sourceType)
+        }
     }
     
     private func submitPost() {
         showingKeyboard = false
-        let post = Post(title: title, text: postContent, author: user)
-        
+        var post = Post(title: title, text: postContent, author: user)
         submitTask.run {
+            if let image = image {
+                post.imageURL = await PostService.uploadPhoto(post.id, image: image)
+            }
             try await PostService.upload(post)
             title = ""
             postContent = ""
+            sourceType = .photoLibrary
+            isSelectingImage = false
+            image = nil
         }
     }
 }

--- a/FirebaseTestProject/Views/PostRow.swift
+++ b/FirebaseTestProject/Views/PostRow.swift
@@ -26,11 +26,29 @@ struct PostRow: View {
             Text(post.author.name)
                 .padding(.bottom, 8)
                 .padding()
+            if post.imageURL != "" {
+                AsyncImage(url: URL(string: post.imageURL), content: { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 300, height: 200)
+                }, placeholder: {
+                    VStack {
+                        Image(systemName: "icloud.and.arrow.down")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 75, height: 50)
+                        Text("Image downloading...")
+                            .font(.caption)
+                    }
+                }
+                )
+            }
             HStack {
-                Text(post.author.name)
                 if let deleteAction = deleteAction {
                     Spacer()
                     deleteButton(with: deleteAction)
+                        .buttonStyle(.borderless)
                 }
             }
             .padding(.bottom, 8)

--- a/FirebaseTestProject/Views/ProfileView.swift
+++ b/FirebaseTestProject/Views/ProfileView.swift
@@ -8,21 +8,65 @@
 import SwiftUI
 
 struct ProfileView: View {
-    let user: User
+    @State var user: User
     let signOutAction: () async throws -> Void
+    @State private var sourceType: UIImagePickerController.SourceType = .photoLibrary
+    @State private var isSelectingImage = false
+    @State private var changingProfilePhoto = false
+    @State private var image: UIImage?
     
     @StateObject private var signOutTask = TaskViewModel()
     
     var body: some View {
         VStack{
-            Image(systemName: "person.circle")
-                .resizable()
-                .scaledToFit()
-                .padding()
-            Button {
-                
-            } label: {
-                Text("Change Photo...")
+            Spacer()
+            if let image = image {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(width: 300, height: 300)
+                    .clipShape(Circle())
+                    .overlay(Circle().stroke(Color.white, lineWidth: 4))
+                    .shadow(radius: 10)
+                HStack(alignment: .center, spacing: 25) {
+                    Button {
+                        signOutTask.run {
+                            user.imageURL = await UserService.uploadPhoto(user, image: image)
+//                            user.imageURL = await UserService.uploadPhoto(user, image: image)
+//                            UserService.updateURL(user, imageURL: user.imageURL)
+                            self.image = nil
+                        }
+                    } label: {
+                        Text("Confirm")
+                    }
+                    Button {self.image = nil} label: {
+                        Text("Cancel")
+                            .foregroundColor(Color.red)
+                    }
+                }
+            } else {
+                AsyncImage(url: URL(string: user.imageURL), content: { image in
+                    image
+                        .resizable()
+                        .aspectRatio(contentMode: .fit)
+                        .frame(width: 300, height: 300)
+                        .clipShape(Circle())
+                        .overlay(Circle().stroke(Color.white, lineWidth: 4))
+                        .shadow(radius: 10)
+                }, placeholder: {
+                    VStack {
+                        Image(systemName: "icloud.and.arrow.down")
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .frame(width: 75, height: 50)
+                        Text("Image downloading...")
+                            .font(.caption)
+                    }
+                }
+                )
+                Button { changingProfilePhoto.toggle()} label: {
+                    Text("Change Photo")
+                }
             }
             Spacer()
             Text("User Name:")
@@ -42,6 +86,18 @@ struct ProfileView: View {
         }
         .alert("Cannot Sign Out", isPresented: $signOutTask.isError, presenting: signOutTask.error, actions: { _ in }) { error in
             Text(error.localizedDescription)
+        }
+        .alert(isPresented: $changingProfilePhoto) {
+            Alert(title: Text("Changing Profile Picture"), message: Text("Select where you would like your image to come from:"), primaryButton: .default(Text("Camera")) {
+                sourceType = .camera
+                isSelectingImage.toggle()
+            }, secondaryButton: .default(Text("Library")) {
+                sourceType = .photoLibrary
+                isSelectingImage.toggle()
+            })
+        }
+        .sheet(isPresented: $isSelectingImage) {
+            ImagePickerView(selectedImage: $image, sourceType: sourceType)
         }
     }
     


### PR DESCRIPTION
- Add imageURLs to posts and users (it only causes errors when it is trying to load old posts that don't have this field. This will not be a problem when we actually build this app for the students because they won't have "old" files in there FireStore.)
- The imageURLs are strings, but they can be nil
- Posts can attach images from either the camera or photo library (camera breaks on sim since it is the sim)
- Changed the way Users are created, now each user in the Firestore Database uses the same string as the UUID that is associated with their Authentication instead of generating a new one, it made it easier to update the document in the collection when everything is referenced by the same uuid string.
- Users are created with the a default profile picture
- Users can go to the profile picture page and change their profile picture
- UserService was modified slightly to incorporate photos
- There are still some notes, comments, and generally rough code, I'll continue to clean this up but wanted to push it out initially now that it is functional.

** There is the occasional time when Images that are associated with the current user will load in the post and then go back to the AsyncImage placeholder as if it is still waiting to download. I'm don't sure if this a simulator thing or what but it doesn't happen every time and it's only the logged-in user's pictures, other author's post's images stay loaded. Still trying to figure this out.

Let me know what y'all think.