### PR TITLE
Fix Favorite Posts Error 

### DIFF
--- a/FirebaseTestProject/Services/PostService.swift
+++ b/FirebaseTestProject/Services/PostService.swift
@@ -35,6 +35,7 @@ struct PostService {
     
     func favoritePosts() async throws -> [Post] {
         let favorites = try await favoritesQuery.getDocuments(as: Favorite.self).map(\.postid.uuidString)
+        guard !favorites.isEmpty else { return [] }
         var posts = try await postsQuery.whereField("id", in: favorites).getDocuments(as: Post.self)
         for i in posts.indices {
             posts[i].isFavorite = true


### PR DESCRIPTION
This PR is fixing an error that users who don't have any favorited posts are seeing after navigating to the Favorites tab. 