### PR TITLE
Sign in with Apple

### DIFF
--- a/FirebaseTestProject.xcodeproj/project.pbxproj
+++ b/FirebaseTestProject.xcodeproj/project.pbxproj
@@ -527,6 +527,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = FirebaseTestProject/FirebaseTestProject.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FirebaseTestProject/Preview Content\"";
@@ -557,6 +558,7 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = FirebaseTestProject/FirebaseTestProject.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"FirebaseTestProject/Preview Content\"";

--- a/FirebaseTestProject/FirebaseTestProject.entitlements
+++ b/FirebaseTestProject/FirebaseTestProject.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/FirebaseTestProject/Services/UserService.swift
+++ b/FirebaseTestProject/Services/UserService.swift
@@ -6,13 +6,19 @@
 //
 
 import Foundation
+import AuthenticationServices
 import FirebaseAuth
 import FirebaseFirestore
+import CryptoKit
+
+// MARK: - UserService
 
 struct UserService {
     var auth = Auth.auth()
     var usersReference = Firestore.firestore().collection("users")
     var cache = Cache<User>(key: "user")
+    
+    // MARK: Create Account
     
     func createAccount(name: String, email: String, password: String) async throws -> User {
         let response = try await auth.createUser(withEmail: email, password: password)
@@ -22,6 +28,8 @@ struct UserService {
         return createdUser
     }
     
+    // MARK: Sign In
+    
     func signIn(email: String, password: String) async throws -> User {
         let response = try await auth.signIn(withEmail: email, password: password)
         guard let signedInUser = try await user(response.user.uid) else {
@@ -30,6 +38,49 @@ struct UserService {
         cache.save(signedInUser)
         return signedInUser
     }
+    
+    func configureAppleSignInRequest(_ request: ASAuthorizationAppleIDRequest) -> String {
+        let nonce = Crypto.nonceString(length: 32)
+        
+        request.requestedScopes = [.fullName, .email]
+        request.nonce = Crypto.sha256(nonce)
+        
+        return nonce
+    }
+    
+    func signInWithApple(_ authorization: ASAuthorization, nonce: String) async throws -> User {
+        guard let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential,
+              let idTokenData = appleIDCredential.identityToken,
+              let idToken = String(data: idTokenData, encoding: .utf8) else {
+                  preconditionFailure()
+              }
+        let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idToken, rawNonce: nonce)
+        let response = try await auth.signIn(with: credential)
+        
+        let userReference = usersReference.document(response.user.uid)
+        let userSnapshot = try await userReference.getDocument()
+        
+        if userSnapshot.exists, let userData = userSnapshot.data() {
+            let user = User(from: userData)
+            cache.save(user)
+            return user
+        }
+        
+        let name = appleIDCredential.fullName?.formatted() ?? ""
+        let user = User(name: name)
+        try await userReference.setData(user.jsonDict)
+        cache.save(user)
+        return user
+    }
+    
+    // MARK: Sign Out
+    
+    func signOut() throws {
+        try auth.signOut()
+        cache.save(nil)
+    }
+    
+    // MARK: Current User
     
     func currentUser() -> User? {
         cache.load()
@@ -46,11 +97,6 @@ struct UserService {
         return user
     }
     
-    func signOut() throws {
-        try auth.signOut()
-        cache.save(nil)
-    }
-    
     private func user(_ uid: String) async throws -> User? {
         let user = try await usersReference.document(uid).getDocument()
         guard let userData = user.data() else {
@@ -58,7 +104,11 @@ struct UserService {
         }
         return User(from: userData)
     }
-    
+}
+
+// MARK: - Cache
+
+extension UserService {
     struct Cache<Record: Codable> {
         var key: String
         var defaults = UserDefaults.standard
@@ -77,5 +127,50 @@ struct UserService {
                 defaults.set(nil, forKey: key)
             }
         }
+    }
+}
+
+// MARK: - Crypto
+
+private enum Crypto {
+    static func nonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> = Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+            
+            randoms.forEach { random in
+                if remainingLength == 0 {
+                    return
+                }
+                
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        
+        return result
+    }
+    
+    static func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            String(format: "%02x", $0)
+        }
+            .joined()
+        return hashString
     }
 }

--- a/FirebaseTestProject/ViewModels/AuthViewModel.swift
+++ b/FirebaseTestProject/ViewModels/AuthViewModel.swift
@@ -6,11 +6,13 @@
 //
 
 import Foundation
+import AuthenticationServices
 
 @MainActor class AuthViewModel: ObservableObject {
     @Published var user: User?
     
     private let userService: UserService
+    private var signInWithAppleNonce: String?
     
     init(userService: UserService = .init()) {
         self.user = userService.currentUser()
@@ -27,6 +29,26 @@ import Foundation
     
     func signIn(email: String, password: String) async throws {
         user = try await userService.signIn(email: email, password: password)
+    }
+    
+    func configureAppleSignInRequest(_ request: ASAuthorizationAppleIDRequest) {
+        signInWithAppleNonce = userService.configureAppleSignInRequest(request)
+    }
+    
+    func signInWithApple(_ result: Result<ASAuthorization, Error>) async throws {
+        switch result {
+        case let .success(authorization):
+            guard let nonce = signInWithAppleNonce else {
+                preconditionFailure("Completion handler for Sign in with Apple called with no nonce present")
+            }
+            user = try await userService.signInWithApple(authorization, nonce: nonce)
+        case let .failure(error):
+            if let error = error as? ASAuthorizationError, error.code == .canceled {
+                return
+            }
+            throw error
+        }
+        signInWithAppleNonce = nil
     }
     
     func signOut() throws {

--- a/FirebaseTestProject/Views/MainTabView.swift
+++ b/FirebaseTestProject/Views/MainTabView.swift
@@ -41,10 +41,8 @@ struct MainTabView: View {
     }
     
     private var unauthenticatedView: some View {
-        SignInView(
-            action: auth.signIn(email:password:),
-            createAccountView: SignUpView(action: auth.createAccount(name:email:password:))
-        )
+        SignInView(createAccountView: SignUpView())
+            .environmentObject(auth)
     }
 }
 

--- a/FirebaseTestProject/Views/SignInView.swift
+++ b/FirebaseTestProject/Views/SignInView.swift
@@ -6,10 +6,11 @@
 //
 
 import SwiftUI
+import AuthenticationServices
 
 struct SignInView<CreateAccountView: View>: View {
-    let action: (String, String) async throws -> Void
     let createAccountView: CreateAccountView
+    @EnvironmentObject private var auth: AuthViewModel
     
     @State private var email = ""
     @State private var password = ""
@@ -36,17 +37,31 @@ struct SignInView<CreateAccountView: View>: View {
                     HStack {
                         Button(action: signIn) {
                             Text("Sign In")
+                                .padding()
+                                .frame(maxWidth: .infinity)
                                 .foregroundColor(Color.white)
-                                .frame(width: 150, height: 50)
                                 .background(Color.blue)
                                 .cornerRadius(15)
                         }
                         NavigationLink("Create Account", destination: createAccountView)
+                            .padding()
+                            .frame(maxWidth: .infinity)
                             .foregroundColor(Color.white)
-                            .frame(width: 150, height: 50)
                             .background(Color.blue)
                             .cornerRadius(15)
                     }
+                    Divider()
+                        .padding(.vertical)
+                    SignInWithAppleButton { request in
+                        auth.configureAppleSignInRequest(request)
+                    } onCompletion: { result in
+                        signInTask.run {
+                            try await auth.signInWithApple(result)
+                        }
+                    }
+                    .signInWithAppleButtonStyle(.black)
+                    .frame(height: 50)
+                    .cornerRadius(15)
                 }
                 .padding()
                 Spacer()
@@ -61,13 +76,14 @@ struct SignInView<CreateAccountView: View>: View {
     
     private func signIn() {
         signInTask.run {
-            try await action(email, password)
+            try await auth.signIn(email: email, password: password)
         }
     }
 }
 
 struct SignInView_Previews: PreviewProvider {
     static var previews: some View {
-        SignInView(action: { _, _ in }, createAccountView: EmptyView())
+        SignInView(createAccountView: EmptyView())
+            .environmentObject(AuthViewModel())
     }
 }


### PR DESCRIPTION
This adds Sign in with Apple to the app.

Before you test:
1. Enable the "Sign in with Apple" capability for this app on the [Certificates, Identifiers, & Profiles](https://developer.apple.com/account/resources/identifiers/list) section of Apple’s developer website.
2. In the Firebase console, go to **Authentication** > **Sign-in methods** and enable Apple as a sign-in provider (already done).
3. It seems that Sign in with Apple [doesn’t work on simulators](https://developer.apple.com/forums/thread/651533), so test using a real device if at all possible.